### PR TITLE
Adiciona Freshchat para atendimento

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -3,3 +3,4 @@ FIREBASE_INITIAL=
 FIREBASE_A=
 FIREBASE_B=
 SERVER_API=https://5mitidksxm7xfn4g4-mock.stoplight-proxy.io/
+FRESHCHAT_TOKEN=

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "axios": "^0.18.0",
     "bowser": "^1.9.4",
     "lodash.isequal": "^4.5.0",
+    "lodash.uniq": "^4.5.0",
     "preact": "^8.2.7",
     "sweetalert2": "^7.15.1"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,7 @@
     <link rel="shortcut icon" href="./assets/favicon.png">
     <link rel="stylesheet" href="https://necolas.github.io/normalize.css/latest/normalize.css">
     <script src="./js/extras/detectIE.js"></script>
+    <script src="https://wchat.freshchat.com/js/widget.js"></script>
 </head>
 <body class="loading">
 
@@ -250,7 +251,17 @@
   </footer>
 
   <div id="chrome-bug-alert"></div>
-
+  <script>
+    window.fcWidget.init({
+      token: process.env.FRESHCHAT_TOKEN,
+      host: 'https://wchat.freshchat.com',
+      config: {
+        cssNames: {
+          widget: 'custom_fc_frame',
+        },
+      },
+    });
+  </script>
 <script src="https://cdn.ravenjs.com/3.25.0/raven.min.js" crossorigin="anonymous"></script>
 <script src="./js/index.js"></script>
 </body>

--- a/src/index.html
+++ b/src/index.html
@@ -251,17 +251,6 @@
   </footer>
 
   <div id="chrome-bug-alert"></div>
-  <script>
-    window.fcWidget.init({
-      token: process.env.FRESHCHAT_TOKEN,
-      host: 'https://wchat.freshchat.com',
-      config: {
-        cssNames: {
-          widget: 'custom_fc_frame',
-        },
-      },
-    });
-  </script>
 <script src="https://cdn.ravenjs.com/3.25.0/raven.min.js" crossorigin="anonymous"></script>
 <script src="./js/index.js"></script>
 </body>

--- a/src/js/ApplicationState.js
+++ b/src/js/ApplicationState.js
@@ -2,6 +2,7 @@ import ViewController from './ViewController';
 import AudioController from './AudioController';
 import UrlHandler from './extras/UrlHandler';
 import { setPaypalKey } from './extras/paypal';
+import { loadChat, destroyChat } from './extras/freshchat';
 
 export const CREATING = 'CREATING';
 export const LOADING = 'LOADING';
@@ -69,7 +70,7 @@ class ApplicationState {
 
       case PLAYING:
         setPaypalKey(key);
-
+        destroyChat();
         try {
           await ViewController.playOpening(opening);
         } catch (error) {
@@ -85,17 +86,20 @@ class ApplicationState {
         break;
 
       case EDITING:
+        loadChat();
         setPaypalKey(key);
         ViewController.setFormValues(opening);
         ViewController.showDownloadButton();
         break;
 
       case DOWNLOAD:
+        loadChat();
         setPaypalKey(key);
         ViewController.setDownloadPage();
         break;
 
       default:
+        loadChat();
         ViewController.unsetLoading();
     }
   }

--- a/src/js/DownloadPage/EmailRequestField.js
+++ b/src/js/DownloadPage/EmailRequestField.js
@@ -32,6 +32,8 @@ class EmailRequestField extends Component {
     if (requestDownloadStatus) {
       finishRequestHandle(requestDownloadStatus, email);
     }
+
+    window.fcWidget.user.setEmail(email);
   }
 
   render() {

--- a/src/js/extras/UserIdentifier.js
+++ b/src/js/extras/UserIdentifier.js
@@ -1,4 +1,5 @@
 import { setGAUser } from './googleanalytics';
+import uniq from 'lodash.uniq';
 
 const KEY = 'KasselLabsUser';
 
@@ -97,6 +98,7 @@ export default class UserIdentifier {
     const user = this._loadUser();
     user.lastEmail = email;
     user.emails.push(email);
+    user.emails = uniq(user.emails);
     Storage.save(user);
   }
 }

--- a/src/js/extras/UserIdentifier.js
+++ b/src/js/extras/UserIdentifier.js
@@ -88,10 +88,24 @@ export default class UserIdentifier {
     setGAUser(email);
   }
 
+  static _setUserFreshchat(user) {
+    const email = user.lastEmail;
+    if (!email) {
+      return;
+    }
+
+    if(window.fcWidget) {
+      window.fcWidget.user.setProperties({
+        email,
+      });
+    }
+  }
+
   static setUser(appName) {
     const user = this._loadUser(appName);
     this._setUserRaven(user);
     this._setUserGtag(user);
+    this._setUserFreshchat(user);
   }
 
   static addEmail(email) {

--- a/src/js/extras/UserIdentifier.js
+++ b/src/js/extras/UserIdentifier.js
@@ -1,5 +1,5 @@
-import { setGAUser } from './googleanalytics';
 import uniq from 'lodash.uniq';
+import { setGAUser } from './googleanalytics';
 
 const KEY = 'KasselLabsUser';
 
@@ -94,7 +94,7 @@ export default class UserIdentifier {
       return;
     }
 
-    if(window.fcWidget) {
+    if (window.fcWidget) {
       window.fcWidget.user.setProperties({
         email,
       });

--- a/src/js/extras/freshchat.js
+++ b/src/js/extras/freshchat.js
@@ -1,0 +1,23 @@
+export const loadChat = () => {
+  if (window.fcWidget.isLoaded()) {
+    return;
+  }
+
+  window.fcWidget.init({
+    token: process.env.FRESHCHAT_TOKEN,
+    host: 'https://wchat.freshchat.com',
+    config: {
+      cssNames: {
+        widget: 'custom_fc_frame',
+      },
+    },
+  });
+};
+
+export const destroyChat = () => {
+  if (window.fcWidget.isLoaded()) {
+    setTimeout(() => {
+      window.fcWidget.destroy();
+    }, 500);
+  }
+};

--- a/src/styles/freshchat.styl
+++ b/src/styles/freshchat.styl
@@ -3,4 +3,8 @@
   @media only screen and (max-device-width : 1024px) {
     right: 15px !important;
   }
+
+  @media mobile {
+    display: none;
+  }
 }

--- a/src/styles/freshchat.styl
+++ b/src/styles/freshchat.styl
@@ -1,0 +1,6 @@
+.custom_fc_frame {
+  right: 160px !important;
+  @media only screen and (max-device-width : 1024px) {
+    right: 15px !important;
+  }
+}

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -213,3 +213,4 @@ buttonStyle() {
 @import './checkChromeBug.styl';
 @import './scrollbar.styl';
 @import './checkForDonation.styl';
+@import './freshchat.styl';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5239,6 +5239,7 @@ lodash.startswith@^4.2.1:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6919329/57054772-073a3100-6c6d-11e9-9c70-891a92684586.png)

Vejam no email `@kassellabs.io`de vocês, cada um recebeu um convite

Alguns pontos para considerar antes:

- Tem várias configurações legais no dashboard do freshchat para usar, coloquei algumas já
- Por padrão mostra nossos nomes para o usuário, dá para esconder (vide agent config [aqui](https://developers.freshchat.com/#customisation-wgt)). Daí o cara vê como Kassel Labs independente de quem atender
- Não achei uma forma de ativar/desativar pela interface, vamos controlar pelo código por enquanto
- **IMPORTANTE**: Esconder (nem que seja com display none) se a página for de uma intro tocando, acho que fica meio ruim se ficar. Não vi ainda como é, mas deve ter algo para isso na [API](https://developers.freshchat.com/) ou configurando pelo dashboard
- No mobile está meio estranho, fica tudo pequeno. @BrOrlandi veja se consegue dar uma olhada nisso