### PR TITLE
Trim logo text.

### DIFF
--- a/src/js/StarWarsAnimation.js
+++ b/src/js/StarWarsAnimation.js
@@ -97,7 +97,7 @@ class StarWarsAnimation {
       logoContainer.classList.add('-firefox-desktop');
     }
 
-    const logoText = opening.logo;
+    const logoText = opening.logo.trim();
     // is default logo
     if (logoText.toLowerCase() === starwarsDefaultText) {
       logoTextContainer.style.display = 'none';


### PR DESCRIPTION
Avoid bug when user inserts an empty line as the first line of the logo.