### PR TITLE
fix: update help.kassellabs.io references to kassellabs.io

### DIFF
--- a/src/donation_cancelled/index.html
+++ b/src/donation_cancelled/index.html
@@ -27,14 +27,14 @@
         You didn't have finished the payment on PayPal.
         If you have questions about the service, please read our FAQ and Terms of Service:
       </p>
-      <a class="contactButton" href="https://help.kassellabs.io/starwars/" rel="noopener noreferrer">
+      <a class="contactButton" href="https://kassellabs.io/help/star-wars-intro-creator" rel="noopener noreferrer">
         FAQ and Contact
       </a>
 
       <p className="termsOfServiceAcceptance">
         By using this website you are agreeing to our
         <a
-          href="https://help.kassellabs.io/starwars/#termsOfService"
+          href="https://kassellabs.io/terms"
           rel="noopener noreferrer"
         >
           Terms of Service

--- a/src/donation_success/index.html
+++ b/src/donation_success/index.html
@@ -28,14 +28,14 @@
         If you paid enough for the video you should receive a confirmation email from us in a few minutes!
         If you don't receive it, please check your spam box or contact us:
       </p>
-      <a class="contactButton" href="https://help.kassellabs.io/starwars/" rel="noopener noreferrer">
+      <a class="contactButton" href="https://kassellabs.io/help/star-wars-intro-creator" rel="noopener noreferrer">
         FAQ and Contact
       </a>
 
       <p className="termsOfServiceAcceptance">
         By using this website you are agreeing to our
         <a
-          href="https://help.kassellabs.io/starwars/#termsOfService"
+          href="https://kassellabs.io/terms"
           rel="noopener noreferrer"
         >
           Terms of Service

--- a/src/index.html
+++ b/src/index.html
@@ -177,7 +177,7 @@
             edit text
           </button>
           <a
-            href="https://help.kassellabs.io/starwars/"
+            href="https://kassellabs.io/help/star-wars-intro-creator"
             rel="noopener noreferrer"
             target="_blank"
             class="help-button"
@@ -237,7 +237,7 @@
       </a>
 
       <a
-        href="https://help.kassellabs.io/starwars/"
+        href="https://kassellabs.io/help/star-wars-intro-creator"
         rel="noopener noreferrer"
         target="_blank"
         >
@@ -245,7 +245,7 @@
       </a>
 
       <a
-        href="https://help.kassellabs.io/starwars/#termsOfService"
+        href="https://kassellabs.io/terms"
         rel="noopener noreferrer"
         target="_blank"
         >
@@ -253,7 +253,7 @@
       </a>
 
       <a
-        href="https://help.kassellabs.io/privacy/"
+        href="https://kassellabs.io/privacy"
         rel="noopener noreferrer"
         target="_blank"
         >

--- a/src/js/DownloadPage/ContactButton.js
+++ b/src/js/DownloadPage/ContactButton.js
@@ -7,7 +7,7 @@ const ContactButton = ({
   const link = (
     <a
       className="contactButton"
-      href="https://help.kassellabs.io/starwars/"
+      href="https://kassellabs.io/help/star-wars-intro-creator"
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/src/js/DownloadPage/TermsOfServiceAcceptance.js
+++ b/src/js/DownloadPage/TermsOfServiceAcceptance.js
@@ -4,7 +4,7 @@ const TermsOfServiceAcceptance = () => (
   <p className="termsOfServiceAcceptance">
     By using this website you are agreeing to our&nbsp;
     <a
-      href="https://help.kassellabs.io/starwars/#termsOfService"
+      href="https://kassellabs.io/terms"
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION
## Summary
- Replace deprecated `help.kassellabs.io` URLs in `src/index.html`, the donation success/cancelled pages, ContactButton, and TermsOfServiceAcceptance
- Point links at the canonical pages on `kassellabs.io`:
  - FAQ / Help / Contact button → `https://kassellabs.io/help/star-wars-intro-creator`
  - TERMS OF SERVICE → `https://kassellabs.io/terms`
  - PRIVACY POLICY → `https://kassellabs.io/privacy`

## Test plan
- [ ] Open the deployed site footer and confirm FAQ, Terms of Service, and Privacy links resolve
- [ ] Confirm the in-player help (`?`) button opens the Star Wars help page
- [ ] Confirm donation success and cancelled pages link correctly