### PR TITLE
feat(redirect): forward old.* to the consolidated new app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,98 +52,28 @@
     -->
 
     <!--
-      A/B test handshake. ONLY runs when served from
-      old.starwarsintrocreator.kassellabs.io (the post-flip legacy home).
-      Stays dormant while this same build is still serving as the canonical
-      `starwarsintrocreator.kassellabs.io` so current production traffic
-      isn't affected before the flip.
-
-      When active, the snippet:
-        1. Reads ?ab_variant= URL param (set by the new app on cross-domain
-           redirect) and persists it to localStorage.
-        2. Reads existing localStorage assignment.
-        3. If neither, defaults to "legacy" since the user is physically on
-           the legacy domain.
-        4. Captures utm_campaign / utm_content from the URL so they survive
-           into the payment flow (GA4 also picks them up automatically).
-      Kept in sync with src/lib/ab-test.ts in the new SWIC repo.
+      old.* → new redirect. The swic-vs-new-2026-q2 A/B concluded 2026-06-17
+      (kassellabs-os/planning/swic-vs-new-ab-test.md). The new app is the
+      consolidated destination; old.* is now a pure forwarder to it. This runs
+      in <head> before the bundle so old.* never fires analytics or paints the
+      legacy UI (body starts display:none). It preserves the path, real query
+      params, and the hash — a legacy deep link carries the intro key in the
+      hash (e.g. #!/<key>/download), and the new app's LegacyHashRedirect lands
+      the visitor on the matching clean URL. Only our own A/B test-helper
+      params are stripped. Mirrors the tested contract in
+      src/js/extras/oldDomainRedirect.js — keep the two in sync.
     -->
     <script>
     (function () {
       if (location.hostname !== 'old.starwarsintrocreator.kassellabs.io') return;
-      var STORAGE_KEY = 'kassel_swic_ab_variant';
-      var EXPERIMENT_ID = 'swic-vs-new-2026-q2';
-
-      function read() {
-        try { return localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
-      }
-      function write(v) {
-        try { localStorage.setItem(STORAGE_KEY, v); } catch (e) { /* noop */ }
-      }
-      function clear() {
-        try { localStorage.removeItem(STORAGE_KEY); } catch (e) { /* noop */ }
-      }
-      function valid(v) { return v === 'new' || v === 'legacy'; }
-
-      function urlParam(name) {
-        var m = new RegExp('[?&]' + name + '=([^&#]*)').exec(location.search);
-        return m ? decodeURIComponent(m[1]) : null;
-      }
-
-      // 0. Reset switch (?ab_reset=1).
-      if (urlParam('ab_reset') === '1') clear();
-
-      // 1. URL handshake (?ab_variant=new|legacy).
-      var fromUrl = urlParam('ab_variant');
-      if (valid(fromUrl)) write(fromUrl);
-
-      // 2. Final resolution. Default to "legacy" — this domain IS the legacy variant.
-      var variant = read();
-      if (!valid(variant)) {
-        variant = 'legacy';
-        write(variant);
-      }
-
-      // 3. Make sure utm_campaign + utm_content are visible to GA4 + payment.
-      // GA4 captures them from the URL on page-load; the payment flow reads
-      // location.search at checkout time.
-      if (urlParam('utm_campaign') !== EXPERIMENT_ID) {
-        try {
-          var url = new URL(location.href);
-          url.searchParams.set('utm_campaign', EXPERIMENT_ID);
-          url.searchParams.set('utm_content', 'ab_' + EXPERIMENT_ID + '_' + variant);
-          // Strip our own test-helper params now that the state is persisted.
-          url.searchParams.delete('ab_variant');
-          url.searchParams.delete('ab_reset');
-          history.replaceState({}, '', url.toString());
-        } catch (e) { /* IE / file:// — skip */ }
-      }
-
-      // Expose the variant for the rest of the app (analytics, payment) and
-      // for debugging in the JS console — window.__KASSEL_AB__.reset() etc.
-      window.__KASSEL_AB__ = {
-        experimentId: EXPERIMENT_ID,
-        variant: variant,
-        utmParams: function () {
-          return {
-            utm_campaign: EXPERIMENT_ID,
-            utm_content: 'ab_' + EXPERIMENT_ID + '_' + variant
-          };
-        },
-        setVariant: function (v) {
-          if (!valid(v)) { console.warn('invalid variant', v); return; }
-          write(v); location.reload();
-        },
-        reset: function () { clear(); location.reload(); },
-        inspect: function () {
-          return {
-            experimentId: EXPERIMENT_ID,
-            variant: variant,
-            storage: read(),
-            url: location.href
-          };
-        }
-      };
+      var params = new URLSearchParams(location.search);
+      ['ab_variant', 'ab_reset', 'ab_no_redirect'].forEach(function (key) {
+        params.delete(key);
+      });
+      var qs = params.toString();
+      var target = 'https://starwarsintrocreator.kassellabs.io'
+        + location.pathname + (qs ? '?' + qs : '') + location.hash;
+      location.replace(target);
     })();
     </script>
 

--- a/src/js/extras/oldDomainRedirect.js
+++ b/src/js/extras/oldDomainRedirect.js
@@ -1,0 +1,41 @@
+// old.starwarsintrocreator.kassellabs.io → starwarsintrocreator.kassellabs.io
+//
+// The swic-vs-new-2026-q2 experiment concluded 2026-06-17 (see
+// kassellabs-os/planning/swic-vs-new-ab-test.md). The new app is the
+// consolidated destination and old.* is now a pure forwarder to it.
+//
+// We preserve the path, the real query params, and the hash. A legacy deep
+// link carries the intro key in the hash (e.g. #!/<key>/download), so
+// forwarding it unchanged lands the visitor on the new domain via the exact
+// same path an old #!/<key> bookmark already takes — the new app's
+// LegacyHashRedirect normalizes #!/<key> to the clean /<key> URL. Only our
+// own A/B test-helper params are stripped.
+//
+// NOTE: the inline <head> snippet in src/index.html runs this same
+// computation before the bundle loads (so old.* never fires analytics or
+// paints the legacy UI). Keep the two in sync — this module is the tested
+// contract (oldDomainRedirect.test.js).
+
+export const OLD_DOMAIN = 'old.starwarsintrocreator.kassellabs.io';
+export const NEW_ORIGIN = 'https://starwarsintrocreator.kassellabs.io';
+
+const AB_HELPER_PARAMS = ['ab_variant', 'ab_reset', 'ab_no_redirect'];
+
+export function oldDomainRedirectTarget(location) {
+  if (!location || location.hostname !== OLD_DOMAIN) return null;
+
+  const params = new URLSearchParams(location.search || '');
+  AB_HELPER_PARAMS.forEach((key) => params.delete(key));
+  const qs = params.toString();
+
+  return NEW_ORIGIN
+    + (location.pathname || '/')
+    + (qs ? `?${qs}` : '')
+    + (location.hash || '');
+}
+
+export function redirectOldDomain(win) {
+  const target = oldDomainRedirectTarget(win.location);
+  if (target) win.location.replace(target);
+  return target;
+}

--- a/src/js/extras/oldDomainRedirect.test.js
+++ b/src/js/extras/oldDomainRedirect.test.js
@@ -1,0 +1,67 @@
+import { oldDomainRedirectTarget, redirectOldDomain } from './oldDomainRedirect';
+
+const OLD = 'old.starwarsintrocreator.kassellabs.io';
+const NEW = 'https://starwarsintrocreator.kassellabs.io';
+
+function loc(opts = {}) {
+  return {
+    hostname: OLD, pathname: '/', search: '', hash: '', ...opts,
+  };
+}
+
+describe('oldDomainRedirectTarget', () => {
+  it('returns null when not on the old domain', () => {
+    expect(oldDomainRedirectTarget(loc({ hostname: 'starwarsintrocreator.kassellabs.io' }))).toBeNull();
+    expect(oldDomainRedirectTarget(loc({ hostname: 'localhost' }))).toBeNull();
+  });
+
+  it('redirects the old homepage to the new origin', () => {
+    expect(oldDomainRedirectTarget(loc())).toBe(`${NEW}/`);
+  });
+
+  it('preserves a legacy hashbang deep link (the intro key lives in the hash)', () => {
+    expect(oldDomainRedirectTarget(loc({ hash: '#!/abc123' }))).toBe(`${NEW}/#!/abc123`);
+  });
+
+  it('preserves a hashbang subpage (e.g. /download/donate)', () => {
+    expect(oldDomainRedirectTarget(loc({ hash: '#!/abc123/download/donate' })))
+      .toBe(`${NEW}/#!/abc123/download/donate`);
+  });
+
+  it('preserves real marketing query params', () => {
+    const t = oldDomainRedirectTarget(loc({ search: '?utm_source=google&utm_medium=cpc&gclid=XYZ' }));
+    expect(t).toBe(`${NEW}/?utm_source=google&utm_medium=cpc&gclid=XYZ`);
+  });
+
+  it('strips A/B test-helper params but keeps the rest', () => {
+    const t = oldDomainRedirectTarget(loc({ search: '?ab_variant=legacy&utm_source=google&ab_reset=1' }));
+    expect(t).toBe(`${NEW}/?utm_source=google`);
+  });
+
+  it('produces a clean URL when the only params were A/B helpers', () => {
+    expect(oldDomainRedirectTarget(loc({ search: '?ab_variant=legacy' }))).toBe(`${NEW}/`);
+  });
+
+  it('preserves path + query + hash together', () => {
+    const t = oldDomainRedirectTarget(loc({ pathname: '/', search: '?utm_source=fb', hash: '#!/k9/edit' }));
+    expect(t).toBe(`${NEW}/?utm_source=fb#!/k9/edit`);
+  });
+});
+
+describe('redirectOldDomain', () => {
+  it('calls location.replace with the target on the old domain', () => {
+    const replace = jest.fn();
+    const win = { location: { ...loc({ hash: '#!/abc123' }), replace } };
+    const ret = redirectOldDomain(win);
+    expect(replace).toHaveBeenCalledWith(`${NEW}/#!/abc123`);
+    expect(ret).toBe(`${NEW}/#!/abc123`);
+  });
+
+  it('does nothing when not on the old domain', () => {
+    const replace = jest.fn();
+    const win = { location: { ...loc({ hostname: 'starwarsintrocreator.kassellabs.io' }), replace } };
+    const ret = redirectOldDomain(win);
+    expect(replace).not.toHaveBeenCalled();
+    expect(ret).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Makes `old.starwarsintrocreator.kassellabs.io` a **pure forwarder** to the consolidated new app (`starwarsintrocreator.kassellabs.io`). Replaces the now-dormant A/B handshake in the `<head>` with a redirect that preserves the path, real query params, and the **hash** — legacy deep links carry the intro key in the hash (e.g. `#!/<key>/download`), and the new app's `LegacyHashRedirect` normalizes that to the clean URL. Only our own A/B test-helper params (`ab_variant`/`ab_reset`/`ab_no_redirect`) are stripped.

Runs in `<head>` before the bundle so `old.*` never fires analytics or paints the legacy UI (body is `display:none` by default → no flash).

## Companion

Pairs with KasselLabs/star-wars-intro-creator-new#13 (which turns off the experiment so the new app stops redirecting *to* `old.*`). Together: 100% of traffic consolidates on the new app, no redirect loop. `old.*` stays deployed as the forwarder/fallback.

## Why

`swic-vs-new-2026-q2` concluded 2026-06-17 — see `kassellabs-os/planning/swic-vs-new-ab-test.md`. Also fixes the SRM noted there (direct `old.*` traffic that bypassed the coin-flip now funnels to new).

## Tests

TDD: `src/js/extras/oldDomainRedirect.js` unit-tested red→green (10 cases: host guard, hashbang deep links + subpages, real-UTM preservation, helper-param stripping). Full jest suite green (19 tests). The inline `<head>` snippet mirrors the tested module.