### PR TITLE
Triple free delivery estimates and disclose watermark

### DIFF
--- a/src/js/DownloadPage/newFlow/NotQueuedPageNew.js
+++ b/src/js/DownloadPage/newFlow/NotQueuedPageNew.js
@@ -13,6 +13,9 @@ const NotQueuedPage = ({ openingKey, finishRequestHandle }) => (
       After the video is ready, it will be sent to your email address.
     </p>
     <p>
+      Free videos include a Kassel Labs watermark unless you pay.
+    </p>
+    <p>
       Your email address will be used only to send the video, but
       you can choose to receive news from Kassel Labs about new releases.
     </p>

--- a/src/js/DownloadPage/newFlow/RequestDownloadPageNew.js
+++ b/src/js/DownloadPage/newFlow/RequestDownloadPageNew.js
@@ -43,6 +43,7 @@ const RequestDownloadPage = ({
         {' '}
         to have your video rendered.
         Free videos will be rendered in the HD quality (1280x720).
+        Free videos include a Kassel Labs watermark unless you pay.
         <p>
           <DonateOrNotDonate question="You can still pay to get it earlier if you want." yesText="Go back to payment" {...props} hideNoDonateOption />
         </p>

--- a/src/js/DownloadPage/newFlow/VideoQueuedPageNew.js
+++ b/src/js/DownloadPage/newFlow/VideoQueuedPageNew.js
@@ -32,7 +32,7 @@ const VideoQueuedPage = ({
         Your video is in the queue to be rendered.
         We provide the video for free, but we have costs with
         the servers where the video are rendered.
-        All the videos are provided without Watermark.
+        Free videos include a Kassel Labs watermark unless you pay.
       </p>
       <p>
         There are

--- a/src/js/DownloadPage/newFlow/freeTierCopy.test.js
+++ b/src/js/DownloadPage/newFlow/freeTierCopy.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import NotQueuedPage from './NotQueuedPageNew';
+import RequestDownloadPage from './RequestDownloadPageNew';
+import VideoQueuedPage from './VideoQueuedPageNew';
+
+jest.mock('./DonateOrNotDonateNew', () => () => null);
+jest.mock('../TermsOfServiceAcceptance', () => () => null);
+jest.mock('../ContactButton', () => () => null);
+jest.mock('../EmailRequestField', () => () => null);
+jest.mock('../PaymentModule', () => () => null);
+jest.mock('../Atat', () => () => null);
+jest.mock('../../extras/auxiliar', () => ({
+  calculateTimeToRender: () => ' 30 minutes',
+}));
+
+const watermarkDisclosure = /include a Kassel Labs watermark unless you pay/i;
+
+describe('free-tier download copy', () => {
+  it('discloses the watermark before the user requests a video', () => {
+    const html = renderToStaticMarkup(
+      <NotQueuedPage openingKey="ABC123" finishRequestHandle={() => {}} />,
+    );
+    expect(html).toMatch(watermarkDisclosure);
+  });
+
+  it('discloses the watermark on the request screen', () => {
+    const html = renderToStaticMarkup(
+      <RequestDownloadPage
+        status={{ status: 'not_queued', queueSize: 10 }}
+        openingKey="ABC123"
+        finishRequestHandle={() => {}}
+      />,
+    );
+    expect(html).toMatch(watermarkDisclosure);
+  });
+
+  it('discloses the watermark while the video is queued', () => {
+    const html = renderToStaticMarkup(
+      <VideoQueuedPage status={{ queuePosition: 10 }} openingKey="ABC123" />,
+    );
+    expect(html).toMatch(watermarkDisclosure);
+  });
+});

--- a/src/js/extras/auxiliar.js
+++ b/src/js/extras/auxiliar.js
@@ -52,14 +52,15 @@ I want to provide the following details:
 
 export const calculateTimeToRender = (queuePosition) => {
   const workers = 4; // We should never have less than 3 workers at the same time
-  const totalMinutes = Math.ceil((queuePosition * 10) / workers);
+  const minutesPerRender = 30;
+  const totalMinutes = Math.ceil((queuePosition * minutesPerRender) / workers);
   const totalHours = Math.ceil(totalMinutes / 60);
   const partialDays = Math.floor(totalHours / 24);
   const totalDays = Math.ceil(totalHours / 24);
   let time = '';
 
   if (queuePosition < 3) {
-    return ' 10 minutes';
+    return ' 30 minutes';
   }
 
   if (partialDays >= 3) {

--- a/src/js/extras/auxiliar.test.js
+++ b/src/js/extras/auxiliar.test.js
@@ -26,19 +26,19 @@ describe('auxiliar functions', () => {
   });
 
   it('should validate all calculateTimeToRender tests', () => {
-    expect(calculateTimeToRender(0)).toBe(' 10 minutes');
-    expect(calculateTimeToRender(1)).toBe(' 10 minutes');
-    expect(calculateTimeToRender(2)).toBe(' 10 minutes');
-    expect(calculateTimeToRender(24)).toBe(' 1 hour');
-    expect(calculateTimeToRender(31)).toBe(' 2 hours');
-    expect(calculateTimeToRender(192)).toBe(' 8 hours');
-    expect(calculateTimeToRender(4 * 50)).toBe(' 9 hours');
-    expect(calculateTimeToRender(4 * 53)).toBe(' 9 hours');
-    expect(calculateTimeToRender(4 * 96)).toBe(' 16 hours');
-    expect(calculateTimeToRender(4 * 100)).toBe(' 17 hours');
-    expect(calculateTimeToRender(4 * 200)).toBe(' 1 day, 10 hours');
-    expect(calculateTimeToRender(4 * 1000)).toBe(' 7 days');
-    expect(calculateTimeToRender(4 * 10000)).toBe(' 70 days');
-    expect(calculateTimeToRender(37000)).toBe(' 65 days');
+    expect(calculateTimeToRender(0)).toBe(' 30 minutes');
+    expect(calculateTimeToRender(1)).toBe(' 30 minutes');
+    expect(calculateTimeToRender(2)).toBe(' 30 minutes');
+    expect(calculateTimeToRender(24)).toBe(' 3 hours');
+    expect(calculateTimeToRender(31)).toBe(' 4 hours');
+    expect(calculateTimeToRender(192)).toBe(' 1 day');
+    expect(calculateTimeToRender(4 * 50)).toBe(' 1 day, 1 hour');
+    expect(calculateTimeToRender(4 * 53)).toBe(' 1 day, 3 hours');
+    expect(calculateTimeToRender(4 * 96)).toBe(' 2 days');
+    expect(calculateTimeToRender(4 * 100)).toBe(' 2 days, 2 hours');
+    expect(calculateTimeToRender(4 * 200)).toBe(' 5 days');
+    expect(calculateTimeToRender(4 * 1000)).toBe(' 21 days');
+    expect(calculateTimeToRender(4 * 10000)).toBe(' 209 days');
+    expect(calculateTimeToRender(37000)).toBe(' 193 days');
   });
 });


### PR DESCRIPTION
## What changed

- keep legacy free queue delivery estimates in lockstep with the modern app at 3× the prior allowance
- replace the outdated “without Watermark” claim and disclose that free videos include a Kassel Labs watermark unless paid
- add regression coverage for estimate formatting and disclosure copy

## Why

The old domain remains reachable and must not contradict the current rendering behavior or show different queue estimates.

## Validation

- `npm test -- --runInBand` — 22 tests passed
- repository-wide legacy lint remains blocked by 208 pre-existing errors unrelated to this patch