### PR TITLE
Show paid delivery time on video option cards

### DIFF
--- a/src/js/DownloadPage/newFlow/VideoOptions.js
+++ b/src/js/DownloadPage/newFlow/VideoOptions.js
@@ -32,6 +32,7 @@ const VideoOptions = ({ updatePaymentAmount }) => {
           <span className="title">HD video</span>
           <span className="description">1280 x 720</span>
           <span className="description">MP4 File</span>
+          <span className="description">Ready in a couple of minutes</span>
           <span className="description">
             Pay at least
             {' '}
@@ -47,6 +48,7 @@ const VideoOptions = ({ updatePaymentAmount }) => {
           <span className="title">Full HD video</span>
           <span className="description">1920 x 1080</span>
           <span className="description">MP4 File</span>
+          <span className="description">Ready in a couple of minutes</span>
           <span className="description">
             Pay at least
             {' '}
@@ -62,7 +64,7 @@ const VideoOptions = ({ updatePaymentAmount }) => {
           <HelpButton>
             A more customizable video with the Death Star image replacement.
             Contact us via email to submit your image.
-            This take usually less than one business day to be delivered.
+            Once submitted, we will start rendering it.
           </HelpButton>
           <img className="deathstar-icon" src={DeathStar} alt="Death Star" />
           <span className="title">
@@ -70,6 +72,7 @@ const VideoOptions = ({ updatePaymentAmount }) => {
             <br />
             + Custom Image
           </span>
+          <span className="description">Ready in a couple of minutes</span>
           <span className="description">
             Pay at least
             {' '}

--- a/src/js/DownloadPage/newFlow/VideoOptions.test.js
+++ b/src/js/DownloadPage/newFlow/VideoOptions.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import VideoOptions from './VideoOptions';
+
+jest.mock('../../../assets/favicon.png', () => 'deathstar.png');
+jest.mock('./HelpButton', () => ({ children }) => children);
+
+describe('VideoOptions', () => {
+  it('promises delivery in a couple of minutes on every card', () => {
+    const html = renderToStaticMarkup(
+      <VideoOptions updatePaymentAmount={() => {}} />,
+    );
+
+    expect(html.match(/Ready in a couple of minutes/g) || []).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## What changed

- show “Ready in a couple of minutes” on all three legacy paid option cards
- replace the custom-image tooltip’s stale business-day statement
- add card-level regression coverage

## Why

The paid delivery advantage should be visible directly on the tier cards and remain consistent across both creator implementations.

## Validation

- `npm test -- --runInBand` — 23 tests passed
- changed-file ESLint — passed