### PR TITLE
Label Star Wars virtual queue positions as estimated

### DIFF
--- a/src/js/DownloadPage/newFlow/RequestDownloadPageNew.js
+++ b/src/js/DownloadPage/newFlow/RequestDownloadPageNew.js
@@ -33,7 +33,7 @@ const RequestDownloadPage = ({
         {' '}
         {isQueued ? qeuedText : notQueuedText}
         {' '}
-        queued at position
+        queued with an estimated queue position of
         {' '}
         <b>{position}</b>
         .

--- a/src/js/DownloadPage/newFlow/VideoQueuedPageNew.js
+++ b/src/js/DownloadPage/newFlow/VideoQueuedPageNew.js
@@ -35,15 +35,12 @@ const VideoQueuedPage = ({
         Free videos include a Kassel Labs watermark unless you pay.
       </p>
       <p>
-        There are
+        Your estimated queue position is
         {' '}
         <b>
           {queuePosition}
-          {' '}
-          videos
         </b>
-        {' '}
-        in front of this request to be rendered and
+        , and it
         may take up to
         <b>{timeToRender}</b>
         {' '}

--- a/src/js/DownloadPage/newFlow/VideoRequestSentNew.js
+++ b/src/js/DownloadPage/newFlow/VideoRequestSentNew.js
@@ -59,7 +59,7 @@ class VideoRequestSent extends Component {
       <p>
         <Atat />
         Your video request has been queued!
-        Your current position on the queue is
+        Your estimated queue position is
         {' '}
         <b>{queuePosition}</b>
         ,

--- a/src/js/DownloadPage/newFlow/freeTierCopy.test.js
+++ b/src/js/DownloadPage/newFlow/freeTierCopy.test.js
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import NotQueuedPage from './NotQueuedPageNew';
 import RequestDownloadPage from './RequestDownloadPageNew';
 import VideoQueuedPage from './VideoQueuedPageNew';
+import VideoRequestSent from './VideoRequestSentNew';
 
 jest.mock('./DonateOrNotDonateNew', () => () => null);
 jest.mock('../TermsOfServiceAcceptance', () => () => null);
@@ -10,6 +11,11 @@ jest.mock('../ContactButton', () => () => null);
 jest.mock('../EmailRequestField', () => () => null);
 jest.mock('../PaymentModule', () => () => null);
 jest.mock('../Atat', () => () => null);
+jest.mock('../SocialButtons', () => () => null);
+jest.mock('../../extras/UrlHandler', () => ({
+  goToDownloadPage: jest.fn(),
+  goToEditPage: jest.fn(),
+}));
 jest.mock('../../extras/auxiliar', () => ({
   calculateTimeToRender: () => ' 30 minutes',
 }));
@@ -33,6 +39,7 @@ describe('free-tier download copy', () => {
       />,
     );
     expect(html).toMatch(watermarkDisclosure);
+    expect(html).toMatch(/estimated queue position/i);
   });
 
   it('discloses the watermark while the video is queued', () => {
@@ -40,5 +47,18 @@ describe('free-tier download copy', () => {
       <VideoQueuedPage status={{ queuePosition: 10 }} openingKey="ABC123" />,
     );
     expect(html).toMatch(watermarkDisclosure);
+    expect(html).toMatch(/estimated queue position/i);
+  });
+
+  it('labels the post-request position as estimated', () => {
+    const html = renderToStaticMarkup(
+      <VideoRequestSent
+        donate={false}
+        openingKey="ABC123"
+        requestStatus={{ queuePosition: 10_325 }}
+        requestEmail="user@example.com"
+      />,
+    );
+    expect(html).toMatch(/estimated queue position/i);
   });
 });


### PR DESCRIPTION
## What changed

- describe queue positions as estimated across the legacy free-request cards
- add copy regression coverage for all three affected states

## Why

The displayed position can include the Star Wars virtual backlog, so the legacy UI should identify it as an estimate.

## Validation

- `npm test -- --runInBand` — 24 tests passed
- `git diff --check`

Targeted ESLint still reports the files' pre-existing import-cycle and PropTypes errors; these text-only changes introduce no new lint diagnostics.